### PR TITLE
Fix deprecated 'clobber' parameter in astropy.io.fits write functions

### DIFF
--- a/stsci/skypac/utils.py
+++ b/stsci/skypac/utils.py
@@ -14,6 +14,7 @@ import os
 import weakref
 import tempfile
 import numpy as np
+import astropy
 from astropy.io import fits
 from os import path
 from copy import copy, deepcopy
@@ -31,6 +32,8 @@ __version__ = '0.2'
 __vdate__ = '11-Jul-2014'
 __author__ = 'Mihai Cara'
 
+# USE_FITS_OVERWRITE is necessary as long as we support astropy versions < 1.3
+USE_FITS_OVERWRITE = astropy.version.major >= 1 and astropy.version.minor >=3
 
 def file_name_components(fname, detect_HST_FITS_suffix=True):
     """
@@ -2106,7 +2109,10 @@ def openImageEx(filename, mode='readonly', dqmode='readonly', memmap=True,
             if verbose:
                 print("Writing out {} as MEF to \'{}\'".format( \
                     ftype, sci_image.mef_fname))
-            hdulist.writeto(sci_image.mef_fname, clobber=clobber)
+            if USE_FITS_OVERWRITE:
+                hdulist.writeto(sci_image.mef_fname, overwrite=clobber)
+            else:
+                hdulist.writeto(sci_image.mef_fname, clobber=clobber)
             sci_image.mef_exists = True
 
         if dq_image.original_exists and not imageOnly and \
@@ -2114,7 +2120,10 @@ def openImageEx(filename, mode='readonly', dqmode='readonly', memmap=True,
             if verbose:
                 print("Writing out DQ {} as MEF to \'{}\'".format( \
                     ftype, dq_image.mef_fname))
-            dqhdulist.writeto(dq_image.mef_fname, clobber=clobber)
+            if USE_FITS_OVERWRITE:
+                dqhdulist.writeto(dq_image.mef_fname, overwrite=clobber)
+            else:
+                dqhdulist.writeto(dq_image.mef_fname, clobber=clobber)
             dq_image.mef_exists = True
 
     rcim_orig = ResourceRefCount(hdulist)


### PR DESCRIPTION
The ``clobber`` parameter in ``astropy.io.fits`` write functions has been deprecated and it has been replaced with ``overwrite``: see https://github.com/astropy/astropy/pull/5171.

This has caused our code (see, e.g., ``drizzlepac`` - https://github.com/spacetelescope/drizzlepac/issues/15) to issue numerous deprecation warnings.

This PR updates the code in ``stsci.skypac`` so that it uses ``overwrite`` for versions of astropy  >= 1.3 and ``clobber`` for verions < 1.3 (for backward compatibility).

This PR addresses issue described in https://github.com/spacetelescope/drizzlepac/issues/15