### PR TITLE
Explicitly set memory mapping to False

### DIFF
--- a/stsci/skypac/parseat.py
+++ b/stsci/skypac/parseat.py
@@ -780,7 +780,7 @@ class FileExtMaskInfo(object):
             else:
                 (im, dq) = openImageEx(img, mode=self._im_fmode,
                                   dqmode=self._dq_fmode,
-                                  memmap=True, saveAsMEF=True,
+                                  memmap=False, saveAsMEF=True,
                                   output_base_fitsname=None,
                                   clobber=self.clobber,
                                   imageOnly=self._dontopenDQ,
@@ -1201,7 +1201,7 @@ class FileExtMaskInfo(object):
                 self._filesig.append(stat)
             else:
                 try:
-                    mask, dq = openImageEx(mask, mode=self._msk_fmode, memmap=True,
+                    mask, dq = openImageEx(mask, mode=self._msk_fmode, memmap=False,
                                 saveAsMEF=True, clobber=self.clobber,
                                 imageOnly=True, openImageHDU=True, openDQHDU=False,
                                 preferMEF=True, verbose=False)

--- a/stsci/skypac/utils.py
+++ b/stsci/skypac/utils.py
@@ -288,7 +288,7 @@ def temp_mask_file(data, rootname, prefix='tmp', suffix='mask',
         return fname
 
     # open the "temporary" file and create a new ImageRef object:
-    mask, dummy = openImageEx(fname, mode='readonly', memmap=True,
+    mask, dummy = openImageEx(fname, mode='readonly', memmap=False,
                     saveAsMEF=False, clobber=False,
                     imageOnly=True, openImageHDU=True, openDQHDU=False,
                     preferMEF=True, verbose=False)
@@ -356,7 +356,7 @@ def get_extver_list(img, extname='SCI'):
         hdulist = img
     elif isinstance(img, str):
         try:
-            (img, dq) = openImageEx(img, mode='readonly', memmap=True,
+            (img, dq) = openImageEx(img, mode='readonly', memmap=False,
                               saveAsMEF=False, output_base_fitsname=None,
                               clobber=False, imageOnly=True,
                               openImageHDU=True, openDQHDU=False,
@@ -1754,7 +1754,7 @@ def _openHDU(imageRef, doOpen, preferMEF, rc_orig, fmode, memmap):
                 rc_new = ResourceRefCount(None)
                 try:
                     hdulist = fits.open(imageRef.mef_fname, mode=fmode,
-                                          memmap=memmap)
+                                        memmap=memmap)
                     rc_new  = ResourceRefCount(hdulist)
                     rc_new.hold()
                     imageRef.extname         = _getExtname(hdulist)


### PR DESCRIPTION
This PR explicitly turns off memory mapping in fits IO functions. This is done in order to reduce the number of file handles used by ``astrodrizzle``. This PR partially addresses issue https://github.com/spacetelescope/drizzlepac/issues/39.
