### PR TITLE
Add __version__ back and fix Python 3 compatibility issues

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = stsci.skypac
-version = 0.9.6
-vdate = 23-October-2017
+version = 0.9.7
+vdate = 24-October-2017
 summary = Sky matching on image mosaic
 # description-file = README
 author = Mihai Cara, Warren Hack, Pey Lian Lim

--- a/stsci/skypac/__init__.py
+++ b/stsci/skypac/__init__.py
@@ -4,6 +4,11 @@
 # upon importing this package.
 from __future__ import print_function
 
+__taskname__ = 'skymatch'
+__version__ = '0.9.7'
+__vdate__ = '24-October-2017'
+__author__ = 'Mihai Cara'
+
 import os
 from . import utils
 from . import parseat
@@ -14,12 +19,6 @@ from . import skymatch
 
 from stsci.tools import teal
 teal.print_tasknames(__name__, os.path.dirname(__file__))
-
-
-__taskname__ = 'skymatch'
-__version__ = '0.9.6'
-__vdate__ = '23-October-2017'
-__author__ = 'Mihai Cara'
 
 
 def help():

--- a/stsci/skypac/region.py
+++ b/stsci/skypac/region.py
@@ -224,7 +224,7 @@ class Polygon(Region):
                 AET = self.update_AET(y, AET)
             scan_line = Edge('scan_line', start=[self._bbox[0], y],
                              stop=[self._bbox[0]+self._bbox[2], y])
-            x = [np.ceil(e.compute_AET_entry(scan_line)[1]) for e in AET if e is not None]
+            x = [int(np.ceil(e.compute_AET_entry(scan_line)[1])) for e in AET if e is not None]
             xnew = np.sort(x)
             if y+self._shifty < 0 or y+self._shifty >= ny:
                 y += 1
@@ -351,24 +351,24 @@ class Edge(object):
         fmt = ""
         if self._name is not None:
             fmt += self._name
-            next=self.next
-            while next is not None:
+            ne = self.next_edge
+            while ne is not None:
                 fmt += "-->"
-                fmt += next._name
-                next = next.next
+                fmt += ne._name
+                ne = ne.next_edge
         return fmt
 
     @property
-    def next(self):
+    def next_edge(self):
         return self._next
 
-    @next.setter
-    def next(self, edge):
+    @next_edge.setter
+    def next_edge(self, edge):
         if self._name is None:
             self._name = edge._name
             self._stop = edge._stop
             self._start = edge._start
-            self._next = edge.next
+            self._next = edge.next_edge
         else:
             self._next = edge
 

--- a/stsci/skypac/utils.py
+++ b/stsci/skypac/utils.py
@@ -24,6 +24,8 @@ from stsci.tools import fileutil, readgeis, convertwaiveredfits
 from .hstinfo import supported_telescopes, supported_instruments, \
      counts_only_instruments, mixed_units_instruments, rates_only_instruments
 
+from . import __version__
+from . import __vdate__
 
 __all__ = ['is_countrate', 'ext2str', 'MultiFileLog',
            'ResourceRefCount', 'ImageRef', 'openImageEx',
@@ -216,7 +218,7 @@ def temp_mask_file(data, rootname, prefix='tmp', suffix='mask',
 
     Examples
     --------
-    >>> import numpy np
+    >>> import numpy as np
     >>> from stsci import skypac
     >>> mask=np.ones((800,800),dtype=np.uint8)
     >>> skypac.utils.temp_mask_file(mask, 'ua0x5001m',


### PR DESCRIPTION
In https://github.com/spacetelescope/stsci.skypac/pull/18 I removed `__version__` from one of the modules that used it for logging. This PR imports package version info back into that module.

In addition, fixed the following two issues that resulted in a crash in Python 3 and higher `numpy` versions:

1. Some array indices were floating point numbers. This PR converts them to integers.
2. Do not override `next` property -> renamed `next` to `next_edge`.