### PR TITLE
Fix WCS._naxis deprecation warnings; Remove Python 2 support

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,40 @@
+[metadata]
+package_name = stsci.skypac
+description = Sky matching on image mosaic
+long_description = README.md
+author = Mihai Cara, Warren Hack, Pey Lian Lim
+author_email = help@stsci.edu
+license = BSD-3-Clause
+version-date = 17-January-2019
+version = 1.0.0.dev
+edit_on_github = False
+github_project = spacetelescope/stsci.skypac
+description-file = README.md
+url = https://github.com/spacetelescope/stsci.skypac
+homepage = https://github.com/spacetelescope/stsci.skypac
+
+[build-sphinx]
+source-dir = docs
+build-dir = docs
+all_files = 1
+
+[upload_docs]
+upload-dir = docs/_build/html
+show-response = 1
+
+[pep8]
+select = E101,W191,W291,W292,W293,W391,E111,E112,E113,E901,E902,E101,W191,W291,W292,W293,W391,E111,E112,E113,E901,E902,E201,E202,E203,E211,E221,E222,E223,E224,E225,E226,E227,E228,E231,E241,E242,E251,E271,E272,E273,E274
+exclude = extern,sphinx,*parsetab.py
+
+[pytest]
+minversion = 2.2
+addopts = --ignore=build
+norecursedirs = build docs/_build relic
+
+[entry_points]
+
 [bdist_wheel]
 # This flag says that the code is written to work on both Python 2 and Python
 # 3. If at all possible, it is good practice to do this. If you cannot, you
 # will need to generate wheels for each Python version that you support.
-universal=1
+universal=0

--- a/stsci/skypac/__init__.py
+++ b/stsci/skypac/__init__.py
@@ -1,11 +1,6 @@
 """skymatch"""
 
-# These lines allow TEAL to print out the names of TEAL-enabled tasks
-# upon importing this package.
-from __future__ import print_function
-
-from .version import *
-__vdate__ = __version_date__  # Backwards compat.
+from .version import __version__, __version_date__
 __taskname__ = 'skymatch'
 __author__ = 'Mihai Cara'
 
@@ -18,11 +13,8 @@ from . import skystatistics
 from . import skyline
 from . import skymatch
 
-
 from stsci.tools import teal
 teal.print_tasknames(__name__, os.path.dirname(__file__))
-
-
 
 
 def help():

--- a/stsci/skypac/hstinfo.py
+++ b/stsci/skypac/hstinfo.py
@@ -2,7 +2,7 @@
 This module provides information about supported HST instruments for use
 by :py:mod:`stsci.skypac` module.
 
-:Authors: Mihai Cara (contact: help@stsci.edu)
+:Authors: Mihai Cara
 
 :License: :doc:`LICENSE`
 

--- a/stsci/skypac/parseat.py
+++ b/stsci/skypac/parseat.py
@@ -2,17 +2,17 @@
 Module for parsing ``@-files`` or user input strings for use
 by :py:mod:`stsci.skypac` module.
 
-:Authors: Mihai Cara (contact: help@stsci.edu)
+:Authors: Mihai Cara
 
 :License: :doc:`LICENSE`
 
 """
-from __future__ import print_function
-
-import os, sys, glob
+import os
+import sys
+import glob
 from copy import copy, deepcopy
-from .utils import MultiFileLog, ImageRef, openImageEx, \
-     count_extensions, get_ext_list, get_extver_list
+from .utils import (MultiFileLog, ImageRef, openImageEx, count_extensions,
+                    get_ext_list, get_extver_list)
 from stsci.tools import fileutil, parseinput
 
 try:
@@ -21,7 +21,7 @@ except:
     osfn = None
 
 __all__ = ['parse_at_file', 'parse_at_line', 'parse_cs_line',
-           'FileExtMaskInfo' ]
+           'FileExtMaskInfo']
 __author__ = 'Mihai Cara'
 
 

--- a/stsci/skypac/region.py
+++ b/stsci/skypac/region.py
@@ -1,7 +1,7 @@
 """
 Polygon filling algorithm.
 
-:Authors: Nadezhda Dencheva, Mihai Cara (contact: help@stsci.edu)
+:Authors: Nadezhda Dencheva, Mihai Cara
 
 :License: :doc:`LICENSE`
 
@@ -21,7 +21,6 @@ Polygon filling algorithm.
 #    http://www.cs.rit.edu/~icss571/filling/how_to.html
 #    http://www.cs.uic.edu/~jbell/CourseNotes/ComputerGraphics/PolygonFilling.html
 #
-from __future__ import division
 from collections import OrderedDict
 import numpy as np
 

--- a/stsci/skypac/skyline.py
+++ b/stsci/skypac/skyline.py
@@ -36,13 +36,11 @@ This process will work reasonably fast as most operations
 are performed using the `SkyLine` objects and WCS information
 solely, not image data itself.
 
-:Authors: Mihai Cara, Warren Hack, Pey-Lian Lim (contact: help@stsci.edu)
+:Authors: Mihai Cara, Warren Hack, Pey-Lian Lim
 
 :License: :doc:`LICENSE`
 
 """
-from __future__ import division, print_function, absolute_import
-
 # STDLIB
 import sys, os
 from copy import copy, deepcopy

--- a/stsci/skypac/skymatch.py
+++ b/stsci/skypac/skymatch.py
@@ -1,13 +1,11 @@
 """
 A module that provides functions for matching sky in overlapping images.
 
-:Authors: Mihai Cara, Warren Hack, Pey-Lian Lim (contact: help@stsci.edu)
+:Authors: Mihai Cara, Warren Hack, Pey-Lian Lim
 
 :License: :doc:`LICENSE`
 
 """
-from __future__ import division, print_function
-
 # STDLIB
 import os
 from datetime import datetime
@@ -34,8 +32,7 @@ from .utils import ext2str, MultiFileLog, ImageRef
 from .parseat import FileExtMaskInfo, parse_cs_line, parse_at_file
 from .skyline import SkyLineMember, SkyLine
 from . import region
-from . import __version__
-from . import __vdate__
+from . import __version__, __version_date__
 
 __all__ = ['TEAL_SkyMatch', 'skymatch']
 __taskname__ = 'skymatch'
@@ -776,7 +773,8 @@ stsci_python_sphinxdocs_2.13/drizzlepac/astrodrizzle.html>`_\ .
 
     #  BEGIN:
     ml.logentry("***** {0} started on {1}", __taskname__, runtime_begin)
-    ml.logentry("      Version {0} ({1})", __version__, __vdate__, skip=1)
+    ml.logentry("      Version {0} ({1})", __version__, __version_date__,
+                skip=1)
 
     if readonly:
         ml.logentry("\'skymatch\' task will be run in read-only mode.",
@@ -1327,7 +1325,7 @@ def _calc_sky(s1, s2, skystat):
 def _member_sky(member, radec, skystat, _dbg_name):
     wcs = member.wcs
 
-    fill_mask = np.zeros((wcs._naxis2, wcs._naxis1), dtype=bool)
+    fill_mask = np.zeros(wcs.array_shape, dtype=bool)
 
     if __local_debug__:
         ivert1 = []
@@ -1514,7 +1512,7 @@ def _apply_skyuser(skyline, readonly_mode, subtractsky, _taskname4history):
     if skyline.members and _taskname4history == 'SkyMatch':
         skyline.members[0].image_hdulist[0].header.add_history(
             '{} by {} {} ({})'.format(hdr_keyword, __taskname__,
-                                      __version__, __vdate__))
+                                      __version__, __version_date__))
 
 
 def _overlap_matrix(skylines, skystat):

--- a/stsci/skypac/skystatistics.py
+++ b/stsci/skypac/skystatistics.py
@@ -2,7 +2,7 @@
 Sky statistics computation class for `~skymatch.skymatch` and
 `~skymatch.skymatch._weighted_sky`.
 
-:Authors: Mihai Cara (contact: help@stsci.edu)
+:Authors: Mihai Cara
 
 :License: :doc:`LICENSE`
 

--- a/stsci/skypac/utils.py
+++ b/stsci/skypac/utils.py
@@ -2,13 +2,11 @@
 This module provides utility functions for use
 by :py:mod:`stsci.skypac` module.
 
-:Authors: Mihai Cara (contact: help@stsci.edu)
+:Authors: Mihai Cara
 
 :License: :doc:`LICENSE`
 
 """
-from __future__ import print_function
-
 import sys
 import os
 import weakref
@@ -21,11 +19,11 @@ import numpy as np
 import astropy
 from astropy.io import fits
 from stsci.tools import fileutil, readgeis, convertwaiveredfits
-from .hstinfo import supported_telescopes, supported_instruments, \
-     counts_only_instruments, mixed_units_instruments, rates_only_instruments
+from .hstinfo import (supported_telescopes, supported_instruments,
+                      counts_only_instruments, mixed_units_instruments,
+                      rates_only_instruments)
 
-from . import __version__
-from . import __vdate__
+from . import __version__, __version_date__
 
 __all__ = ['is_countrate', 'ext2str', 'MultiFileLog',
            'ResourceRefCount', 'ImageRef', 'openImageEx',
@@ -34,9 +32,6 @@ __all__ = ['is_countrate', 'ext2str', 'MultiFileLog',
            'almost_equal', 'skyval2txt']
 
 __author__ = 'Mihai Cara'
-
-
-ASTROPY_VER_GE13 = LooseVersion(astropy.__version__) >= LooseVersion('1.3')
 
 
 def file_name_components(fname, detect_HST_FITS_suffix=True):
@@ -2123,10 +2118,7 @@ def openImageEx(filename, mode='readonly', dqmode='readonly', memmap=True,
             if verbose:
                 print("Writing out {} as MEF to \'{}\'".format( \
                     ftype, sci_image.mef_fname))
-            if ASTROPY_VER_GE13:
-                hdulist.writeto(sci_image.mef_fname, overwrite=clobber)
-            else:
-                hdulist.writeto(sci_image.mef_fname, clobber=clobber)
+            hdulist.writeto(sci_image.mef_fname, overwrite=clobber)
             sci_image.mef_exists = True
 
         if dq_image.original_exists and not imageOnly and \
@@ -2134,10 +2126,7 @@ def openImageEx(filename, mode='readonly', dqmode='readonly', memmap=True,
             if verbose:
                 print("Writing out DQ {} as MEF to \'{}\'".format( \
                     ftype, dq_image.mef_fname))
-            if ASTROPY_VER_GE13:
-                dqhdulist.writeto(dq_image.mef_fname, overwrite=clobber)
-            else:
-                dqhdulist.writeto(dq_image.mef_fname, clobber=clobber)
+            dqhdulist.writeto(dq_image.mef_fname, overwrite=clobber)
             dq_image.mef_exists = True
 
     rcim_orig = ResourceRefCount(hdulist)


### PR DESCRIPTION
This PR deals with two issues:

1. Fixes deprecation warnings due to deprecation of the `WCS._naxis1` - see https://github.com/spacetelescope/drizzlepac/issues/186

2. Remove support for Python 2.