### PR TITLE
Fix typo: shpinx -> sphinx

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,7 @@ INSTALL_REQUIRES=[
     'stsci.imagestats',
     'stsci.tools',
     'stwcs',
-    'shpinx'
+    'sphinx'
 ]
 
 # Distribute compiled documentation alongside the installed package


### PR DESCRIPTION
Allows development builds of packages that depend on `stsci.skypac` to succeed.