### PR TITLE
Fix setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,6 @@
 [build-system]
-requires = ["setuptools>=38.2.5", "wheel", "numpy", "sphinx"]
+requires = [
+    "setuptools>=38.2.5",
+    "wheel",
+    "numpy",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools>=38.2.5", "wheel", "numpy", "sphinx"]

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ import shutil
 from configparser import ConfigParser
 from setuptools import setup, find_packages
 from subprocess import check_call, CalledProcessError
-from setuptools import setup, find_packages, Extension, _install_setup_requires
+from setuptools import setup, find_packages, Extension
 from setuptools.command.install import install
 
 try:
@@ -37,23 +37,6 @@ LICENSE = metadata.get('license', 'BSD-3-Clause')
 this_dir = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(this_dir, LONG_DESCRIPTION), encoding='utf-8') as f:
     long_description = f.read()
-
-# Due to overriding `install` and `build_sphinx` we need to download
-# setup_requires dependencies before reaching `setup()`. This allows
-# `sphinx` to exist before the `BuildSphinx` class is injected.
-SETUP_REQUIRES = [
-    'sphinx',
-]
-
-_install_setup_requires(dict(setup_requires=SETUP_REQUIRES))
-for dep_pkg in SETUP_REQUIRES:
-    try:
-        importlib.import_module(dep_pkg)
-    except ImportError:
-        print("{0} is required in order to install '{1}'.\n"
-              "Please install {0} first.".format(dep_pkg, PACKAGENAME),
-              file=sys.stderr)
-        exit(1)
 
 # release version control:
 if not pkgutil.find_loader('relic'):

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,8 @@
 import os
 import pkgutil
 import sys
-import importlib
-import inspect
-import shutil
-from configparser import ConfigParser
 from setuptools import setup, find_packages
 from subprocess import check_call, CalledProcessError
-from setuptools import setup, find_packages, Extension
-from setuptools.command.install import install
 
 try:
     from distutils.config import ConfigParser
@@ -92,59 +86,15 @@ PACKAGE_DATA = {
     ],
 }
 
-INSTALL_REQUIRES=[
+INSTALL_REQUIRES = [
     'astropy>=3.1',
     'numpy',
     'spherical_geometry>=1.2.2',
     'stsci.imagestats',
     'stsci.tools',
     'stwcs',
-    'sphinx'
 ]
 
-# Distribute compiled documentation alongside the installed package
-docs_compiled_src = os.path.normpath('build/sphinx/html')
-docs_compiled_dest = os.path.normpath(
-    '{0}/htmlhelp'.format(os.path.join(*PACKAGENAME.split('.')))
-)
-
-class InstallCommand(install):
-    """ Inform users to build (if desired) html help locally. """
-    def run(self):
-        super().run()
-
-        if not os.path.exists(docs_compiled_dest):
-            print('\nwarning: Sphinx "htmlhelp" documentation was NOT bundled!\n'
-                  '         Execute the following then reinstall:\n\n'
-                  '         $ python setup.py build_sphinx\n\n',
-                  file=sys.stderr)
-
-from sphinx.cmd.build import build_main
-from sphinx.setup_command import BuildDoc
-
-class BuildSphinx(BuildDoc):
-    """Build Sphinx documentation after compiling C extensions"""
-
-    description = 'Build Sphinx documentation'
-
-    def initialize_options(self):
-        BuildDoc.initialize_options(self)
-
-    def finalize_options(self):
-        BuildDoc.finalize_options(self)
-
-    def run(self):
-        build_cmd = self.reinitialize_command('build_ext')
-        build_cmd.inplace = 1
-        self.run_command('build_ext')
-        build_main(['-b', 'html', 'docs/source', 'build/sphinx/html'])
-
-        # Bundle documentation inside of drizzlepac
-        if os.path.exists(docs_compiled_src):
-            if os.path.exists(docs_compiled_dest):
-                shutil.rmtree(docs_compiled_dest)
-
-            shutil.copytree(docs_compiled_src, docs_compiled_dest)
 
 setup(
     name=PACKAGENAME,
@@ -166,13 +116,9 @@ setup(
     install_requires=INSTALL_REQUIRES,
     packages=find_packages(),
     package_data=PACKAGE_DATA,
-    cmdclass={
-        'install': InstallCommand,
-        'build_sphinx': BuildSphinx,
-    },
     project_urls={
         'Bug Reports': 'https://github.com/spacetelescope/stsci.skypac/issues/',
         'Source': 'https://github.com/spacetelescope/stsci.skypac/',
         'Help': 'https://hsthelp.stsci.edu/',
-        },
+    },
 )


### PR DESCRIPTION
Latest `setuptools` produces the following error during build:
```        
from setuptools import setup, find_packages, Extension, _install_setup_requires
ImportError: cannot import name '_install_setup_requires'
```

This implements `pyproject.toml` (PEP517) as a replacement.