### PR TITLE
Undo switching to astropy.nddata.bitmask

### DIFF
--- a/stsci/skypac/skyline.py
+++ b/stsci/skypac/skyline.py
@@ -52,9 +52,12 @@ import math
 # THIRD-PARTY
 from stwcs import wcsutil
 from astropy import wcs as pywcs
-#from astropy.nddata.bitmask import interpret_bit_flags
 from stwcs.distortion.utils import output_wcs
 from spherical_geometry.polygon import SphericalPolygon
+try:
+    from stsci.tools.bitmask import bitfield_to_boolean_mask
+except ImportError:
+    from stsci.tools.bitmask import bitmask2mask as bitfield_to_boolean_mask
 
 # LOCAL
 from .utils import (is_countrate, ext2str, MultiFileLog, ImageRef,

--- a/stsci/skypac/skymatch.py
+++ b/stsci/skypac/skymatch.py
@@ -15,7 +15,10 @@ import copy
 # THIRD PARTY
 import numpy as np
 from astropy.io import fits
-from astropy.nddata.bitmask import interpret_bit_flags
+try:
+    from stsci.tools.bitmask import interpret_bit_flags
+except ImportError:
+    from stsci.tools.bitmask import interpret_bits_value as interpret_bit_flags
 
 try:
     from stsci.tools import teal


### PR DESCRIPTION
This effectively undoes #61 for the reasons explained in https://github.com/spacetelescope/stsci.tools/pull/135#issuecomment-896792533: `numpy 1.21` compatibility can be improved in `stsci.tools.bitmask` before next `astropy` release.