### PR TITLE
Use intrinsic int, bool, and float types instead of numpy

### DIFF
--- a/stsci/skypac/pamutils.py
+++ b/stsci/skypac/pamutils.py
@@ -83,8 +83,8 @@ def _compute_pam_sd(wcs, shape=None, blc=(1, 1), idcscale=1.0, cdscale=1.0):
         return rf * np.ones(shape, dtype=np.float64)
 
     # prepare coordinates:
-    x = np.arange(shape[1], dtype=np.float) - wcs.sip.crpix[0] + float(blc[0])
-    y = np.arange(shape[0], dtype=np.float) - wcs.sip.crpix[1] + float(blc[1])
+    x = np.arange(shape[1], dtype=float) - wcs.sip.crpix[0] + float(blc[0])
+    y = np.arange(shape[0], dtype=float) - wcs.sip.crpix[1] + float(blc[1])
 
     ar = np.arange(wcs.sip.a_order + 1)
     br = np.arange(wcs.sip.b_order + 1)

--- a/stsci/skypac/region.py
+++ b/stsci/skypac/region.py
@@ -422,7 +422,7 @@ class Edge(object):
         w = self._start - edge._start
         D = np.cross(u, v)
         if np.allclose(np.cross(u, v), 0, rtol=0,
-                       atol=1e2 * np.finfo(np.float).eps):
+                       atol=1e2 * np.finfo(float).eps):
             return np.array(self._start)
 
         return np.cross(v, w) / D * u + self._start
@@ -431,7 +431,7 @@ class Edge(object):
         u = self._stop - self._start
         v = edge._stop - edge._start
         return np.allclose(np.cross(u, v), 0, rtol=0,
-                           atol=1e2 * np.finfo(np.float).eps)
+                           atol=1e2 * np.finfo(float).eps)
 
 
 def _round_vertex(v):

--- a/stsci/skypac/skymatch.py
+++ b/stsci/skypac/skymatch.py
@@ -1640,7 +1640,7 @@ def _find_optimum_sky_deltas(skylines, skystat, mlog):
     except np.linalg.LinAlgError:
         mlog.warning("Unable to compute sky: No valid data in common "
                      "image areas")
-        deltas = np.full(ns, np.nan, dtype=np.float)
+        deltas = np.full(ns, np.nan, dtype=float)
         return deltas
 
     if rank < ns - 1:
@@ -1750,7 +1750,7 @@ def _find_optimum_sky_deltas_wlead(skylines, skystat, mlog):
     except np.linalg.LinAlgError:
         mlog.warning("Unable to compute sky: No valid data in common "
                      "image areas")
-        deltas = np.full(ns, np.nan, dtype=np.float)
+        deltas = np.full(ns, np.nan, dtype=float)
         return deltas
 
     if rank < ns - 1:


### PR DESCRIPTION
This replaces the deprecated `numpy` global types

```python
np.float
np.bool
np.int
```

with the Python types

```python
float
bool
int
```
 
to avoid (reduce) deprecation warnings.