### PR TITLE
Increase tolerance for considering two polygons to be identical

### DIFF
--- a/stsci/skypac/skymatch.py
+++ b/stsci/skypac/skymatch.py
@@ -1321,7 +1321,7 @@ def _calc_sky(s1, s2, skystat):
         for m2 in s2.members:
             pts1 = np.sort(list(m1.polygon.points)[0], axis=0)
             pts2 = np.sort(list(m2.polygon.points)[0], axis=0)
-            if np.allclose(pts1, pts2, rtol=0, atol=5e-9):
+            if np.allclose(pts1, pts2, rtol=0, atol=1e-8):
                 intersect_poly = m1.polygon.copy()
             else:
                 intersect_poly = m1.polygon.intersection(m2.polygon)


### PR DESCRIPTION
@stsci-hack reported - see #65 - that in a small number of cases there still are some crashes due to accuracy loss in the spherical geometry package. The workaround to this loss of accuracy issue was to identify two polygons as being identical if their vertices are within a specific proximity to each other. @stsci-hack reports that increasing tolerance by 2x would solve the issue for those HST data sets for which current tolerance was too small.

In my estimates, for ACS/HRC detectors with 0.025'' pixel scale, increasing tolerance to 1e-8 would be an equivalent to a tolerance of about 0.08 pixels in input image pixels.

Closes #65