### PR TITLE
remove usages of deprecated `codecov` package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,6 @@ TESTS_REQUIRE = [
     'pytest',
     'pytest-cov',
     'pytest-doctestplus',
-    'codecov',
 ]
 
 DOCS_REQUIRE = [


### PR DESCRIPTION
the `codecov` package is now deprecated and has been yanked from PyPI