### PR TITLE
Switch to using astropy's bitmask module.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,14 @@
 [project]
 name = "stsci.skypac"
 description = "Sky matching on image mosaic"
-requires-python = ">=3.5"
+requires-python = ">=3.10"
 authors = [
     { name = "Mihai Cara", email = "help@stsci.edu" },
     { name = "Warren Hack" },
     { name = "Pey Lian Lim" },
 ]
 dependencies = [
-    "astropy>=3.1",
+    "astropy>=5.0.4",
     "numpy",
     "spherical_geometry>=1.2.2",
     "stsci.imagestats",

--- a/stsci/skypac/skyline.py
+++ b/stsci/skypac/skyline.py
@@ -54,10 +54,7 @@ from stwcs import wcsutil
 from astropy import wcs as pywcs
 from stwcs.distortion.utils import output_wcs
 from spherical_geometry.polygon import SphericalPolygon
-try:
-    from stsci.tools.bitmask import bitfield_to_boolean_mask
-except ImportError:
-    from stsci.tools.bitmask import bitmask2mask as bitfield_to_boolean_mask
+from astropy.nddata.bitmask import bitfield_to_boolean_mask
 
 # LOCAL
 from .utils import (is_countrate, ext2str, MultiFileLog, ImageRef,

--- a/stsci/skypac/skymatch.py
+++ b/stsci/skypac/skymatch.py
@@ -15,10 +15,7 @@ import copy
 # THIRD PARTY
 import numpy as np
 from astropy.io import fits
-try:
-    from stsci.tools.bitmask import interpret_bit_flags
-except ImportError:
-    from stsci.tools.bitmask import interpret_bits_value as interpret_bit_flags
+from astropy.nddata.bitmask import interpret_bit_flags
 
 try:
     from stsci.tools import teal


### PR DESCRIPTION
This PR switches the code to use `astropy.nddata.bitmask` functions instead of our code from `stsci.tools`. This re-does #61 .

Closes #57 