### PR TITLE
[SCSB-205] `project.license.file` -> `project.license-files`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "stwcs",
     "packaging>=19.0",
 ]
+license-files = ["LICENSE.txt"]
 dynamic = [
     "version"
 ]
@@ -23,10 +24,6 @@ dynamic = [
 [project.readme]
 file = "README.md"
 content-type = "text/markdown"
-
-[project.license]
-file = "LICENSE.txt"
-content-type = "text/plain"
 
 [project.urls]
 repository = "https://github.com/spacetelescope/stsci.skypac"


### PR DESCRIPTION
the `project.license` entry is changing to just use SPDX expressions; license files are moving to `project.license-files` ([PEP 639](https://peps.python.org/pep-0639/))